### PR TITLE
Change repo url from antmicro forks to upstreams

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -1,1 +1,22 @@
-{"cores": [{"repository_name": "ibex", "repository_url": "https://www.github.com/antmicro/ibex", "repository_branch": "master", "repository_revision": "37745c5c729110d0cde2c8fb1c9c0e7365feea0f"}, {"repository_name": "Cores-VeeR-EL2", "repository_url": "https://github.com/antmicro/Cores-VeeR-EL2", "repository_branch": "main", "repository_revision": "e0a34dfb32ce4aa1c4dce71357dd6d21ed5fdef6"}, {"repository_name": "caliptra-rtl", "repository_url": "https://github.com/chipsalliance/caliptra-rtl", "repository_branch": "main", "repository_revision": "61fb5bd9eff399947f6e8621bdb1de03ff06e1b8"}]}
+{
+    "cores": [
+        {
+            "repository_name": "ibex",
+            "repository_url": "https://github.com/lowRISC/ibex",
+            "repository_branch": "master",
+            "repository_revision": "4e17587213bd310a1140b8f80cb6b258e33b94e2"
+        },
+        {
+            "repository_name": "Cores-VeeR-EL2",
+            "repository_url": "https://github.com/chipsalliance/Cores-VeeR-EL2",
+            "repository_branch": "main",
+            "repository_revision": "982fd6904c3d574370f84a546b8485f81574c426"
+        },
+        {
+            "repository_name": "caliptra-rtl",
+            "repository_url": "https://github.com/chipsalliance/caliptra-rtl",
+            "repository_branch": "main",
+            "repository_revision": "61fb5bd9eff399947f6e8621bdb1de03ff06e1b8"
+        }
+    ]
+}


### PR DESCRIPTION
In this PR I've changed repository links from antmicro forks to upstreams of Ibex and VeeR-EL2